### PR TITLE
Prefer 'class X; class Y' instead of the short form

### DIFF
--- a/styleguide/README.md
+++ b/styleguide/README.md
@@ -276,6 +276,7 @@ to
 
 ``` ruby
 class X::Y
+end
 ```
 
 but use the latter if you must.


### PR DESCRIPTION
The person who was a strong proponent for the short form no longer works here. I believe the rest of us prefer this form.

See it rendered: https://github.com/henrik/devbook/blob/classes/styleguide/README.md#prefer-class-x-class-y-for-nested-classesmodules
- [x] HN
- [x] VA
- [x] AR
- [x] KP
- [x] TS
- [x] JK
