### PR TITLE
Styleguide: specify SQL direction explicitly

### DIFF
--- a/styleguide/README.md
+++ b/styleguide/README.md
@@ -470,6 +470,10 @@ scope :later_alligator, later.alligator                 # now = server launch ti
 
 Write `foo.bar IS NOT NULL`, never `foo.bar is not null`.
 
+#### Explicitly state SQL sort direction.
+
+Write `order("name ASC")`, never `order("name")`.
+
 #### Avoid SQL outside models.
 
 Ideally, each model encapsulates its underlying table. Changes to the table shouldn't need to break the model's API. Specifically:


### PR DESCRIPTION
I prefer to have it explicit: when it's implicit, I find I have to stop and think what the default order is, and I worry about whether the person who wrote the SQL actually thought about direction or not.

What do you guys think?

- [x] HN
- [ ] KP
- [x] AR
- [x] TS
- [x] JK