### PR TITLE
Styleguide: no quote-style exception for Gemfile

### DIFF
--- a/styleguide/README.md
+++ b/styleguide/README.md
@@ -421,8 +421,6 @@ Single-quoted strings [aren't faster](http://stackoverflow.com/questions/1836467
 
 But don't escape quotes inside a string if you don't need to. Change the quote style instead: `'like "this"'` or `%{'like' "this"}`.
 
-In contexts (specifically, in `Gemfile`) where single quotes are conventional, respect that convention.
-
 ### Use strings for complex i18n keys.
 
 Do `t("this.here")` and not `t(:"this.here")`.


### PR DESCRIPTION
I realized I don't like this exception. I don't see any benefit in complicating our rule. It's not a strong de-facto convention AFAIK, to have single quotes there. Sometimes we forget and use double quotes in Gemfile or routes or whatever. Changing those files to use double quotes instead would be a tiny amount of work.

What do you think?

- [x] HN
- [x] KP
- [x] AR
- [x] TS
- [x] JK