### PR TITLE
TZ safety: also applies to scripts we keep

### DIFF
--- a/styleguide/README.md
+++ b/styleguide/README.md
@@ -669,9 +669,13 @@ We should write "time zone safe" code when we can:
   * use `Time.zone.mktime` instead of `Time.mktime`
   * other similar cases (update this section if you encounter them)
 
-Sometimes it doesn't really matter and isn't worth the effort. In those cases, say so in a comment so others know it's not an oversight:
+Sometimes it doesn't really matter and isn't worth the effort. In those cases, say so in a comment so others know:
 
-`# It is not important that this is time zone safe.`
+`# This might not be time zone safe but that's acceptable.`
+
+The above applies equally to any scripts we keep around: if they stay in the repo to be run again, or modified, or copy-pasted from, they should be either safe or explicitly unsafe.
+
+For code we don't keep around, anything goes, of course.
 
 #### Use `require_dependency` to require app code.
 


### PR DESCRIPTION
- [x] HN
- [x] AR
- [x] KP
- [x] JK
- [x] TS

From discussion: https://github.com/barsoom/auctionet/commit/e8fa349a20930ca24bfbc414a5c417666e0444f5#commitcomment-17932070

NOTE: If we reject this change, we could instead change the styleguide to explicitly say that anything goes in scripts whether one-off or not, so we don't need to have this discussion again.