### PR TITLE
Styleguide: Prefer non-dynamic dirty tracking methods

### DIFF
--- a/styleguide/README.md
+++ b/styleguide/README.md
@@ -624,6 +624,24 @@ gem "redis", "~> 2.0"
 ---
 ### Active Record
 
+#### Prefer non-dynamic dirty tracking methods.
+
+Do e.g.
+
+``` ruby
+attribute_was("title")
+saved_change_to_attribute?("title")
+```
+
+rather than
+
+``` ruby
+title_was
+saved_change_to_title?
+```
+
+Because it arguably reads a little clearer, being more clearly distinct from an attribute (especially in the case of `xxx_was`). It's incidentally also slightly more performant and easier to find in documentation.
+
 #### Avoid `default_scope`.
 
 It tends to cause confusing behavior.

--- a/styleguide/README.md
+++ b/styleguide/README.md
@@ -629,18 +629,18 @@ gem "redis", "~> 2.0"
 Do e.g.
 
 ``` ruby
-attribute_was("title")
+attribute_before_last_save("title")
 saved_change_to_attribute?("title")
 ```
 
 rather than
 
 ``` ruby
-title_was
+title_before_last_save
 saved_change_to_title?
 ```
 
-Because it arguably reads a little clearer, being more clearly distinct from an attribute (especially in the case of `xxx_was`). It's incidentally also slightly more performant and easier to find in documentation.
+Because it arguably reads a little clearer, being more clearly distinct from an attribute. It's incidentally also slightly more performant and easier to find in documentation.
 
 #### Avoid `default_scope`.
 


### PR DESCRIPTION
I haven't seen any indications that Rails is moving away from the dynamic methods, and doc examples mostly seem to mention the dynamic ones, but I still prefer the more explicit ones.

I asked on Twitter and the people who answered agreed with me, though admittedly it's not a scientific poll :) https://twitter.com/henrik/status/1296746920782827522