### PR TITLE
Add DOD item about trying to avoid adding 'debt' tasks.

### DIFF
--- a/definition_of_done/README.md
+++ b/definition_of_done/README.md
@@ -25,6 +25,9 @@ When is a feature ["done done"](http://chrislema.com/what-is-done-done/) so its 
 * Code making network requests, e.g. calling APIs, gracefully handles common network errors (see: [Sidekiq retries](http://disq.us/p/1wr05yx), [NetHttpTimeoutErrors](https://github.com/barsoom/net_http_timeout_errors))
 * If it's an email: there's a `mail_view` preview
 * If it's a document (e.g. PDF): there's a `document_previews` preview
+* If the feature has a known element of manual work that it might generate
+  - Get sign-off from the team that this new task it introduces is manageable, and that it does not create an undue amount of work. Ideally no feature should "cost" future work, but it might be ok for edge cases that happen very rarely.
+  - Document the task, and make it require as little context as possible. Add the context in a potential error message or in the task instructions.
 
 ## Changes to the public site
 


### PR DESCRIPTION
We have had extensive discussions about this topic and in order for us to try to be in agreement about how to go about leaving work behind for future devs it would be good to have this formalised here.

I think the spirit should be that we should *never* add future work when we are building features. We do add future work in maintenance and things we don't anticipate anyways, this is just a way to not add work debt consciously.