### PR TITLE
README about libraries: Let go of unused Autho dependency

### DIFF
--- a/libs/README.md
+++ b/libs/README.md
@@ -13,7 +13,6 @@ We want to move in the direction of many small, focused libraries that do things
 This is what we have so far:
 
 * [ActiveModel::SecurePassword](http://api.rubyonrails.org/classes/ActiveModel/SecurePassword/ClassMethods.html) for encrypting passwords, validating confirmation etc.
-* [Autho](http://github.com/henrik/autho) for auth and session management.
 * [go_to_param](https://github.com/henrik/go_to_param/) to redirect where you wanted to go after logging in.
 
 ## Breadcrumbs


### PR DESCRIPTION
We are not using this library, and will not be using it in newer projects.