### PR TITLE
Styleguide: casing in shell scripts

### DIFF
--- a/styleguide/README.md
+++ b/styleguide/README.md
@@ -118,6 +118,26 @@ If a flag is still unclear, consider documenting it:
 `curl --insecure https://example.com`
 ```
 
+#### Use `lower_snake_case` for functions and non-environment variables
+
+``` bash
+foo_bar="baz"
+my_func() { … }
+```
+
+A fairly arbitrary choice, inspired by [Google's style guide](https://google.github.io/styleguide/shellguide.html#function-names).
+
+#### Use `UPPER_SNAKE_CASE` for environment variables
+
+``` bash
+echo "Getting ${MY_VALUE} from e.g. the hosting or CI provider"
+
+# Exporting it ourselves for use in subprocesses.
+export FOO_BAR="baz"
+```
+
+This is conventional and lets us distinguish them from other variables with lesser scope.
+
 ---
 ### HTML
 

--- a/styleguide/README.md
+++ b/styleguide/README.md
@@ -122,7 +122,7 @@ If a flag is still unclear, consider documenting it:
 
 ``` bash
 foo_bar="baz"
-my_func() { … }
+my_func () { … }
 ```
 
 A fairly arbitrary choice, inspired by [Google's style guide](https://google.github.io/styleguide/shellguide.html#function-names).

--- a/styleguide/README.md
+++ b/styleguide/README.md
@@ -125,7 +125,7 @@ foo_bar="baz"
 my_func () { … }
 ```
 
-A fairly arbitrary choice, inspired by [Google's style guide](https://google.github.io/styleguide/shellguide.html#function-names).
+An arbitrary choice, inspired by [Google's style guide](https://google.github.io/styleguide/shellguide.html#function-names).
 
 #### Use `UPPER_SNAKE_CASE` for environment variables
 


### PR DESCRIPTION
Discussion: https://auctionet.slack.com/archives/CF9SAN79V/p1637165952079500

I don't think the env bit is controversial or really needs saying, but let's be extra explicit since we say to make others lowercase.

Did not mention shell variables, which are also typically capitalized, since they can be thought of as a kind of environment variable and we probably don't need to explicitly cover them.

(Going by the definition of env and shell variables here: https://www.digitalocean.com/community/tutorials/how-to-read-and-set-environmental-and-shell-variables-on-linux)