### PR TITLE
deploy without downtime: Remove Rails 4 patch

### DIFF
--- a/deploy_without_downtime/README.md
+++ b/deploy_without_downtime/README.md
@@ -100,8 +100,6 @@ Specifically:
 
   * Deploy 3: Remove the code that ignored the column.
 
-  If you get "PG::InFailedSqlTransaction" errors, you may be on Rails 4 and need [this monkeypatch](https://github.com/rails/rails/issues/12330#issuecomment-244930976).
-
 ### Renaming columns
 
 * **Renaming columns** is never safe.


### PR DESCRIPTION
This drops an older note.